### PR TITLE
Make AMI selection dynamic

### DIFF
--- a/fog-aws-testing/terraform/arch.tf
+++ b/fog-aws-testing/terraform/arch.tf
@@ -1,6 +1,6 @@
 
 resource "aws_instance" "arch" {
-  ami           = "${var.amis["arch"]}"
+  ami           = "${data.aws_ami.arch.id}"
   instance_type = "t3.micro"
   subnet_id = "${aws_subnet.public-subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.allow-bastion.id}"]

--- a/fog-aws-testing/terraform/bastion.tf
+++ b/fog-aws-testing/terraform/bastion.tf
@@ -1,7 +1,7 @@
 
 
 resource "aws_instance" "bastion" {
-  ami           = "${var.amis["debian9"]}"
+  ami           = "${data.aws_ami.debian9.id}"
   instance_type = "t3.nano"
   subnet_id = "${aws_subnet.public-subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.sg-ssh.id}"]

--- a/fog-aws-testing/terraform/centos7.tf
+++ b/fog-aws-testing/terraform/centos7.tf
@@ -1,6 +1,6 @@
 
 resource "aws_instance" "centos7" {
-  ami           = "${var.amis["centos7"]}"
+  ami           = "${data.aws_ami.centos7.id}"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public-subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.allow-bastion.id}"]

--- a/fog-aws-testing/terraform/centos7.tf
+++ b/fog-aws-testing/terraform/centos7.tf
@@ -1,6 +1,6 @@
 
 resource "aws_instance" "centos7" {
-  ami           = "${data.aws_ami.centos7.id}"
+  ami = "${data.aws_ami.centos7.id}"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public-subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.allow-bastion.id}"]

--- a/fog-aws-testing/terraform/debian9.tf
+++ b/fog-aws-testing/terraform/debian9.tf
@@ -1,6 +1,6 @@
 
 resource "aws_instance" "debian9" {
-  ami           = "${var.amis["debian9"]}"
+  ami           = "${data.aws_ami.debian9.id}"
   instance_type = "t3.micro"
   subnet_id = "${aws_subnet.public-subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.allow-bastion.id}"]

--- a/fog-aws-testing/terraform/fedora29.tf
+++ b/fog-aws-testing/terraform/fedora29.tf
@@ -1,6 +1,6 @@
 
 resource "aws_instance" "fedora29" {
-  ami           = "${var.amis["fedora29"]}"
+  ami           = "${data.aws_ami.fedora29.id}"
   instance_type = "t3.micro"
   subnet_id = "${aws_subnet.public-subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.allow-bastion.id}"]

--- a/fog-aws-testing/terraform/rhel7.tf
+++ b/fog-aws-testing/terraform/rhel7.tf
@@ -1,6 +1,6 @@
 
 resource "aws_instance" "rhel7" {
-  ami           = "${var.amis["rhel7"]}"
+  ami           = "${data.aws_ami.rhel7.id}"
   instance_type = "t3.micro"
   subnet_id = "${aws_subnet.public-subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.allow-bastion.id}"]

--- a/fog-aws-testing/terraform/ubuntu18_04.tf
+++ b/fog-aws-testing/terraform/ubuntu18_04.tf
@@ -1,6 +1,6 @@
 
 resource "aws_instance" "ubuntu18_04" {
-  ami           = "${var.amis["ubuntu18_04"]}"
+  ami           = "${data.aws_ami.ubuntu18.id}"
   instance_type = "t3.micro"
   subnet_id = "${aws_subnet.public-subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.allow-bastion.id}"]

--- a/fog-aws-testing/terraform/variables.tf
+++ b/fog-aws-testing/terraform/variables.tf
@@ -68,7 +68,7 @@ data "aws_ami" "centos7" {
   owners = ["679593333241"]
   filter {
     name   = "name"
-    values = ["CentOS Linux 7 x86_64 HVM EBS*"]
+    values = ["CentOS Linux 7 x86_64 HVM EBS 1801_01-*-ami-*"]
   }
 }
 

--- a/fog-aws-testing/terraform/variables.tf
+++ b/fog-aws-testing/terraform/variables.tf
@@ -32,19 +32,6 @@ variable "fog-project-repo" {
     default = "https://github.com/FOGProject/fogproject.git"
 }
 
-# Usernames: https://alestic.com/2014/01/ec2-ssh-username/
-
-variable "amis" {
-  type    = "map"
-  default = {
-    "debian9" = "ami-0f9e7e8867f55fd8e" # https://wiki.debian.org/Cloud/AmazonEC2Image/Stretch
-    "centos7" = "ami-4bf3d731" # https://wiki.centos.org/Cloud/AWS
-    "rhel7" = "ami-c998b6b2" # https://access.redhat.com/articles/3135091
-    "fedora29" = "ami-0ca275747dcc62c18" # https://alt.fedoraproject.org/cloud/
-    "arch" = "ami-099a97582fc329220" # https://www.uplinklabs.net/projects/arch-linux-on-ec2/
-    "ubuntu18_04" = "ami-07025b83b4379007e" # https://cloud-images.ubuntu.com/locator/ec2/
-  }
-}
 
 variable "zone_id" {
     type = "string"
@@ -55,5 +42,81 @@ variable "zone_name" {
     type = "string"
     default = "theworkmans.us"
 } 
+
+# Manual lookup of AMIs from official provider websites.
+# debian https://wiki.debian.org/Cloud/AmazonEC2Image/Stretch
+# centos https://wiki.centos.org/Cloud/AWS
+# rhel7 https://access.redhat.com/articles/3135091
+# fedora https://alt.fedoraproject.org/cloud/
+# arch https://www.uplinklabs.net/projects/arch-linux-on-ec2/
+# ubuntu https://cloud-images.ubuntu.com/locator/ec2/
+
+# Usernames: https://alestic.com/2014/01/ec2-ssh-username/
+
+
+data "aws_ami" "debian9" {
+  most_recent = true
+  owners = ["379101102735"]
+  filter {
+    name   = "name"
+    values = ["debian-stretch-hvm-x86_64-gp2-*"]
+  }
+}
+
+data "aws_ami" "centos7" {
+  most_recent = true
+  owners = ["679593333241"]
+  filter {
+    name   = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS*"]
+  }
+}
+
+data "aws_ami" "rhel7" {
+  most_recent = true
+  owners = ["309956199498"]
+  filter {
+    name   = "name"
+    values = ["RHEL-7.*_HVM_GA-*-x86_64-2-Hourly2-GP2"]
+  }
+}
+
+data "aws_ami" "fedora29" {
+  most_recent = true
+  owners = ["125523088429"]
+  filter {
+    name   = "name"
+    values = ["Fedora-Cloud-Base-29-*.x86_64-hvm-*-gp2*"]
+  }
+}
+
+data "aws_ami" "arch" {
+  most_recent = true
+  owners = ["093273469852"]
+  filter {
+    name   = "name"
+    values = ["arch-linux-lts-hvm-*.x86_64-ebs"]
+  }
+}
+
+data "aws_ami" "ubuntu18" {
+  most_recent = true
+  owners = ["099720109477"]
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]  
+  }
+}
+
+
+
 
 


### PR DESCRIPTION
This should greatly simplify fixing 'stuck' Ubuntu updates by simply re-running the Terraform which should grab an AMI that already has these Ubuntu updates in it, thus fixing being stuck.