### PR TITLE
Hold back the signed rEFInd binaries in both sync directions

### DIFF
--- a/CopyBackTrunk/copybacktrunk.sh
+++ b/CopyBackTrunk/copybacktrunk.sh
@@ -201,6 +201,17 @@ excludes=(
     --exclude='service/ipxe/arm_init.cpio.gz'
     # _resignKernels' pre-signature snapshots of the above.
     --exclude='*.unsigned'
+    # rEFInd, and this is the direction that BREAKS BOOTING. Unlike the
+    # kernels above these ARE tracked, so the checkout genuinely has a copy to
+    # deploy -- carrying only the upstream signature. installfog.sh
+    # countersigns the deployed ones with the server's own Secure Boot key, so
+    # syncing the repo copy over a signed one strips that countersignature and
+    # Secure Boot clients stop booting with nothing on the server to explain
+    # why. Re-run installfog.sh to update and re-sign these.
+    --exclude='service/ipxe/refind*.efi'
+    # Installer-downloaded ESP archives; gitignored, so the checkout has
+    # nothing to deploy and syncing would only delete the server's.
+    --exclude='service/localboot/'
 )
 
 # Point a symlink at the versioned tree, whatever is sitting there now.

--- a/CopyToSVN/copytosvn.sh
+++ b/CopyToSVN/copytosvn.sh
@@ -156,6 +156,18 @@ excludes=(
     --exclude='service/ipxe/arm_init.cpio.gz'
     --exclude='service/ipxe/*.sha256'
     --exclude='*.unsigned'
+    # rEFInd, same reason, and unlike the kernels above these ARE tracked --
+    # so pulling them in is a real content change to committed files rather
+    # than an ignored one. installfog.sh countersigns the deployed copies with
+    # the server's own Secure Boot key, so a pulled refind_x64.efi carries two
+    # signatures (Roderick W. Smith upstream, plus "FOG Project Secure Boot
+    # Signing" from whichever box it came off). Committing that publishes one
+    # server's locally-signed binary as the upstream source.
+    --exclude='service/ipxe/refind*.efi'
+    # ESP archives downloaded by the installer. Gitignored (*.zip), so they
+    # would never be committed -- but pulling ~20MB of them into the checkout
+    # on every run is pure noise.
+    --exclude='service/localboot/'
     # The installer's holding page; not part of the application.
     --exclude='maintenance'
     # Editor leftovers.

--- a/test-signed-artifacts-excluded.sh
+++ b/test-signed-artifacts-excluded.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# Pins that neither sync direction moves a Secure Boot signed artifact.
+#
+# Why this exists
+# ---------------
+# installfog.sh countersigns the deployed kernels and rEFInd binaries with the
+# server's OWN Secure Boot key. The tracked copies carry only the upstream
+# signature. So the two directions fail differently and both fail quietly:
+#
+#   web -> git   pulls a locally-countersigned binary into the checkout, where
+#                committing it publishes one server's signing key's output as
+#                though it were the upstream source. refind*.efi is TRACKED,
+#                so this is a real content change to a committed file, not an
+#                ignored stray -- `git status` shows "M", nothing else does.
+#
+#   git -> web   deploys the repo copy over the signed one, stripping the
+#                countersignature. Secure Boot clients then stop booting, with
+#                nothing on the server to say why.
+#
+# This was not hypothetical: on 2026-08-27 a web -> git run pulled all four
+# refind*.efi into the fogproject checkout, each carrying a second signature
+# from "CN=FOG Project Secure Boot Signing". The kernels were already excluded
+# in both scripts; rEFInd never was.
+#
+# Both excludes arrays are extracted from their scripts and fed to a REAL
+# rsync. No webroot, no checkout, no sudo.
+#
+# Usage: bash test-signed-artifacts-excluded.sh
+# Exit 0 = pass, 1 = fail.
+
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+note() { echo "FAIL: $*"; failures=$((failures + 1)); }
+
+# Artifacts installfog.sh signs or downloads, which must not cross in either
+# direction, and one file that must still cross so an over-broad exclude is
+# caught.
+signed=(
+    service/ipxe/refind.efi
+    service/ipxe/refind_x64.efi
+    service/ipxe/refind_ia32.efi
+    service/ipxe/refind_aa64.efi
+    service/ipxe/bzImage
+    service/ipxe/bzImage32
+    service/ipxe/init.xz
+    service/localboot/fog-esp-x86_64.zip
+)
+must_cross=(
+    service/ipxe/refind.conf
+    management/index.php
+    service/Pre_Stage1.php
+)
+
+check_direction() {
+    local label=$1 script=$2
+    local arr=$work/$label.excludes.sh
+    local src=$work/$label/src dst=$work/$label/dst
+
+    sed -n '/^excludes=(/,/^)$/p' "$here/$script" > "$arr"
+    grep -q "service/ipxe/bzImage" "$arr" \
+        || { note "$label: excludes array not found in $script"; return; }
+
+    rm -rf "$work/$label"
+    mkdir -p "$src" "$dst"
+    local rel
+    for rel in "${signed[@]}" "${must_cross[@]}"; do
+        mkdir -p "$src/$(dirname "$rel")"
+        echo "content of $rel" > "$src/$rel"
+    done
+
+    (
+        # shellcheck disable=SC1090
+        source "$arr"
+        rsync -a --no-links --delete "${excludes[@]}" "$src/" "$dst"
+    ) >/dev/null 2>&1 || note "$label: rsync exited non-zero"
+
+    for rel in "${signed[@]}"; do
+        [[ -e $dst/$rel ]] && note "$label: $rel crossed -- a signed or downloaded artifact was synced"
+    done
+    for rel in "${must_cross[@]}"; do
+        [[ -e $dst/$rel ]] || note "$label: $rel did NOT cross -- an exclude is too broad"
+    done
+}
+
+check_direction web-to-git CopyToSVN/copytosvn.sh
+check_direction git-to-web CopyBackTrunk/copybacktrunk.sh
+
+if [[ $failures -gt 0 ]]; then
+    echo "$failures failure(s)"
+    exit 1
+fi
+echo "signed-artifacts: ${#signed[@]} artifacts held back in both directions,"
+echo "                  ${#must_cross[@]} real files still cross"
+echo "PASS"
+exit 0


### PR DESCRIPTION
Found live while checking something else, not by reading the scripts.

## What happened

A web → git run on 2026-08-27 left all four `refind*.efi` **modified** in the
fogproject checkout. `sbverify` on the pulled copy against `HEAD`:

```
checkout:  /CN=Roderick W. Smith  +  /CN=FOG Project Secure Boot Signing
HEAD:      /CN=Roderick W. Smith
```

`installfog.sh` countersigns the deployed binaries with the server's own Secure
Boot key. Both scripts already exclude the **kernels** for exactly that reason.
Neither excluded rEFInd.

## Why rEFInd is the worse miss

The kernels are gitignored, so a stray copy in the checkout is inert. `refind*.efi`
is **tracked** — so a pull is a content change to a committed file. `git status`
says `M`; nothing else says anything.

| Direction | Failure |
|---|---|
| web → git | publishes one server's locally-signed output as the upstream source |
| git → web | strips the countersignature; Secure Boot clients stop booting, nothing on the server explains why |

The second is the one that breaks a lab, and it is live today on any box where
someone deploys after an install.

## `service/localboot/`

Installer-downloaded ESP archives, gitignored — never a correctness problem in
the pull direction, just ~20MB of noise per run. In the deploy direction the
checkout has nothing to sync and `--delete` would remove the server's.

## `refind*.efi`, not `refind*`

`service/ipxe/refind.conf` is a real tracked config file that must keep
crossing. That is an assertion in the test, not a comment.

## The test

`test-signed-artifacts-excluded.sh` at the repo root, because this is one
invariant spanning both scripts. It extracts **both** `excludes` arrays from
their scripts rather than restating them, and drives a **real rsync** in each
direction. No webroot, no checkout, no sudo.

Eight artifacts must be held back; three real files must still cross.

| Mutation | Result |
|---|---|
| drop the web→git refind exclude | 4 artifacts crossed |
| drop the git→web refind exclude | 4 artifacts crossed |
| drop the localboot exclude | zip crossed |
| widen to `refind*` | `refind.conf` stopped crossing |
